### PR TITLE
Refactor(65): 백테스트 실행하기 인풋 형식 수정

### DIFF
--- a/src/main/java/com/quantweb/springserver/domain/back_test/DTO/request/BackTestInput.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/DTO/request/BackTestInput.java
@@ -2,6 +2,7 @@ package com.quantweb.springserver.domain.back_test.DTO.request;
 
 import com.google.gson.annotations.SerializedName;
 
+import com.quantweb.springserver.domain.back_test.entity.TechnicalStrategy;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,6 @@ import java.util.List;
 @Getter
 @RequiredArgsConstructor
 public class BackTestInput {
-	private String name;
 
 	@SerializedName(value = "strategy_setup")
 	private StrategySetup strategy_setup;
@@ -42,7 +42,7 @@ public class BackTestInput {
 		private String ohlcv;
 
 		@SerializedName("backtest_strategy")
-		private String backtest_strategy;
+		private TechnicalStrategy backtest_strategy;
 
 		@SerializedName("technical_analysis_strategy")
 		private List<TechnicalAnalysisStrategy> technical_analysis_strategy;

--- a/src/main/java/com/quantweb/springserver/domain/back_test/converter/BackTestConverter.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/converter/BackTestConverter.java
@@ -26,7 +26,7 @@ public class BackTestConverter {
 
         return BackTest.builder()
                 .user(user)
-                .name(backTestInput.getName())
+                .name(backTestInput.getStrategy_setup().getStrategy_name())
                 .stockNum(backTestInput.getStrategy_setup().getStock_selection())
                 .initInvestmentFund(responseDto.getInitial_amount())
                 .fees(backTestInput.getStrategy_setup().getFee())
@@ -39,7 +39,7 @@ public class BackTestConverter {
                 .finalAsset(responseDto.getFinal_asset())
                 .marketShared(false)
                 .deletedAt(null)
-                .technicalStrategy(TechnicalStrategy.valueOf(backTestInput.getStrategy_setup().getStrategy_name()))
+                .technicalStrategy(backTestInput.getStrategy_setup().getBacktest_strategy())
                 .build();
     }
 

--- a/src/main/java/com/quantweb/springserver/domain/back_test/entity/TechnicalStrategy.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/entity/TechnicalStrategy.java
@@ -1,7 +1,6 @@
 package com.quantweb.springserver.domain.back_test.entity;
 
 public enum TechnicalStrategy {
-    start_backtest,
     STATIC_ASSET_ALLOCATION,
     TACTICAL_ALSSET_ALLOCATION,
     MACD,

--- a/src/main/java/com/quantweb/springserver/domain/back_test/service/BackTestService.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/service/BackTestService.java
@@ -58,7 +58,7 @@ public class BackTestService {
 
 		User findUser = userRepository.findById(userId).orElseThrow(()-> new RuntimeException("사용자 정보가 존재하지 않습니다."));
 
-		if (backTestRepository.existsByName(backTestInput.getName())) {
+		if (backTestRepository.existsByName(backTestInput.getStrategy_setup().getStrategy_name())) {
 			throw new RuntimeException("이미 사용중인 이름 입니다.");
 		}
 


### PR DESCRIPTION


## 📝작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 전략 타입 enum으로 수정 및 전략 이름 가져오는 부분 수정

### BackTestInput
```java
@SerializedName("backtest_strategy")
		private TechnicalStrategy backtest_strategy;
```

### BackTestConverter
```java
return BackTest.builder()
                .user(user)
                .name(backTestInput.getStrategy_setup().getStrategy_name())
                .stockNum(backTestInput.getStrategy_setup().getStock_selection())
                .initInvestmentFund(responseDto.getInitial_amount())
                .fees(backTestInput.getStrategy_setup().getFee())
                .finalAsset(responseDto.getFinal_asset())
                .marketShared(false)
                .deletedAt(null)
                .technicalStrategy(backTestInput.getStrategy_setup().getBacktest_strategy())
                .build();
```

## #️⃣연관된 이슈

ex) #65 
