### PR TITLE
Feature(64): 백테스트 수정/삭제하기

### DIFF
--- a/src/main/java/com/quantweb/springserver/common/exception/ErrorCode.java
+++ b/src/main/java/com/quantweb/springserver/common/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode implements CustomErrorCode{
 
     //BACKTEST
     BACKTEST_NOT_FOUND("BACKTEST401", HttpStatus.NOT_FOUND,"백테스트를 찾을 수 없습니다."),
+    BACKTEST_BAD_REQUEST("BACKTEST400", HttpStatus.BAD_REQUEST, "이미 동일한 전략이름이 존재합니다."),
+    BACKTEST_UNAUTHORIZED("BACKTEST402",HttpStatus.UNAUTHORIZED,"백테스트에 접근할 권한이 없습니다."),
 
     //INVESTMENT
     INVESTMENTSIMULATION_NOT_FOUND("INVESTMENTSIMULATION401", HttpStatus.NOT_FOUND,"모의투자 를 찾을 수 없습니다.");

--- a/src/main/java/com/quantweb/springserver/domain/back_test/DTO/request/BackTestRequestDto.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/DTO/request/BackTestRequestDto.java
@@ -1,6 +1,31 @@
 package com.quantweb.springserver.domain.back_test.DTO.request;
 
+import com.quantweb.springserver.domain.back_test.DTO.response.InvestmentResultDto;
+import com.quantweb.springserver.domain.back_test.DTO.response.StrategyInfoDto;
+import com.quantweb.springserver.domain.back_test.entity.TechnicalStrategy;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class BackTestRequestDto {
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BackTestSaveDto{
+        private BackTestInfo backTestInfo;
+        private InvestmentResultDto investment_result;
+        private StrategyInfoDto strategy_info;
 
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BackTestInfo {
+            private String name;
+            private Integer stockNum;
+            private Float fees;
+            private String rebalancingPeriod;
+            private TechnicalStrategy technicalStrategy;
+        }
+    }
 }

--- a/src/main/java/com/quantweb/springserver/domain/back_test/DTO/response/BackTestResponseDto.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/DTO/response/BackTestResponseDto.java
@@ -2,13 +2,28 @@ package com.quantweb.springserver.domain.back_test.DTO.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class BackTestResponseDto {
 
-    private Long backtestId;
-    private String backtestName;
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BackTestCreateDto{
+        private InvestmentResultDto investment_result;
+        private StrategyInfoDto strategy_info;
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BackTestSaveDto{
+        private Long backtestId;
+        private String backtestName;
+
+    }
+
+
 }

--- a/src/main/java/com/quantweb/springserver/domain/back_test/controller/BackTestController.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/controller/BackTestController.java
@@ -3,6 +3,7 @@ package com.quantweb.springserver.domain.back_test.controller;
 import com.quantweb.springserver.domain.auth.config.AuthenticationPrincipal;
 import com.quantweb.springserver.domain.back_test.DTO.request.BackTestInput;
 
+import com.quantweb.springserver.domain.back_test.DTO.request.BackTestRequestDto;
 import com.quantweb.springserver.domain.back_test.DTO.response.BackTestDetailsDto;
 import com.quantweb.springserver.domain.back_test.DTO.response.BackTestResponseDto;
 
@@ -42,15 +43,31 @@ public class BackTestController {
     private final TransactionHistoryService transactionHistoryService;
 
 	@PostMapping
-    @Operation(summary = "백테스트 실행하기 API",description = "")
+    @Operation(summary = "백테스트 실행하기 API",description = "백테스팅 실행하기")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "백테스트 이름이 중복되었습니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "입력 값이 잘못되었습니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
     })
 	@Authenticated
-	public ResponseEntity<BackTestResponseDto> backTest(@AuthenticationPrincipal Long userId, @RequestBody BackTestInput backTestInput) {
-		return ResponseEntity.ok(backTestService.backtestAndSave(userId, backTestInput));
+	public ResponseEntity<BackTestResponseDto.BackTestCreateDto> createBackTest(@RequestBody BackTestInput backTestInput) {
+		return ResponseEntity.ok(backTestService.createBackTest(backTestInput));
 	}
+
+    @PostMapping("/save")
+    @Operation(summary = "백테스트 저장하기 API",description = "백테스팅 저장하기")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "이미 동일한 전략 이름이 존재합니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "backtestName", description = "전략 이름 입력"),
+
+    })
+    @Authenticated
+    public ResponseEntity<BackTestResponseDto.BackTestSaveDto> saveBackTest(@AuthenticationPrincipal Long userId,
+                                                                            @RequestBody BackTestRequestDto.BackTestSaveDto backTestResult) {
+        return ResponseEntity.ok(backTestService.saveBackTest(userId, backTestResult));
+    }
 
     @GetMapping("/{backtestId}/details")
     @Operation(summary = "백테스트 기존 전략 결과 상세 조회 API",description = "")
@@ -100,9 +117,9 @@ public class BackTestController {
 
     })
     @Authenticated
-    public ResponseEntity<List<BackTestResponseDto>> getMyBacktests(@AuthenticationPrincipal @PathVariable("userId") Long userId){
+    public ResponseEntity<List<BackTestResponseDto.BackTestSaveDto>> getMyBacktests(@AuthenticationPrincipal @PathVariable("userId") Long userId){
 
-        List<BackTestResponseDto> resultDto = backTestService.getMyBacktests(userId);
+        List<BackTestResponseDto.BackTestSaveDto> resultDto = backTestService.getMyBacktests(userId);
 
         return ResponseEntity.ok(resultDto);
     }
@@ -133,7 +150,7 @@ public class BackTestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "백테스트 이름이 중복되었습니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
     })
     @Authenticated
-    public ResponseEntity<BackTestResponseDto> deleteBackTest(@AuthenticationPrincipal Long userId, @PathVariable("backtestId") Long backtestId) {
+    public ResponseEntity<BackTestResponseDto.BackTestSaveDto> deleteBackTest(@AuthenticationPrincipal Long userId, @PathVariable("backtestId") Long backtestId) {
         return ResponseEntity.ok(backTestService.deleteBacktest(userId, backtestId));
     }
 }

--- a/src/main/java/com/quantweb/springserver/domain/back_test/controller/BackTestController.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/controller/BackTestController.java
@@ -41,14 +41,14 @@ public class BackTestController {
     private final StockService stockService;
     private final TransactionHistoryService transactionHistoryService;
 
-	@PostMapping("/{userId}")
+	@PostMapping
     @Operation(summary = "백테스트 실행하기 API",description = "")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "백테스트 이름이 중복되었습니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
     })
 	@Authenticated
-	public ResponseEntity<BackTestResponseDto> backTest(@AuthenticationPrincipal @PathVariable("userId") Long userId, @RequestBody BackTestInput backTestInput) {
+	public ResponseEntity<BackTestResponseDto> backTest(@AuthenticationPrincipal Long userId, @RequestBody BackTestInput backTestInput) {
 		return ResponseEntity.ok(backTestService.backtestAndSave(userId, backTestInput));
 	}
 
@@ -83,13 +83,13 @@ public class BackTestController {
     })
     @Authenticated
 
-    public ResponseEntity<StockResponseDto> getInvestmentSectors(@AuthenticationPrincipal @PathVariable("backtestId") Long backtestId){
+    public ResponseEntity<StockResponseDto> getInvestmentSectors(@PathVariable("backtestId") Long backtestId){
         StockResponseDto resultDto = stockService.getInvestmentSectors(backtestId);
 
         return ResponseEntity.ok(resultDto);
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping
     @Operation(summary = "내 백테스트 전략들 조회 API",description = "")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -100,7 +100,7 @@ public class BackTestController {
 
     })
     @Authenticated
-    public ResponseEntity<List<BackTestResponseDto>> getMyBacktests(@PathVariable("userId") Long userId){
+    public ResponseEntity<List<BackTestResponseDto>> getMyBacktests(@AuthenticationPrincipal @PathVariable("userId") Long userId){
 
         List<BackTestResponseDto> resultDto = backTestService.getMyBacktests(userId);
 
@@ -125,4 +125,15 @@ public class BackTestController {
         return ResponseEntity.ok(resultDto);
     }
 
+
+    @DeleteMapping("/{backtestId}")
+    @Operation(summary = "백테스트 삭제하기 API",description = "백테스팅 삭제하기")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BACKTEST400", description = "백테스트 이름이 중복되었습니다.",content = @Content(schema = @Schema(implementation = EntityResponse.class))),
+    })
+    @Authenticated
+    public ResponseEntity<BackTestResponseDto> deleteBackTest(@AuthenticationPrincipal Long userId, @PathVariable("backtestId") Long backtestId) {
+        return ResponseEntity.ok(backTestService.deleteBacktest(userId, backtestId));
+    }
 }

--- a/src/main/java/com/quantweb/springserver/domain/back_test/converter/BackTestConverter.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/converter/BackTestConverter.java
@@ -2,6 +2,7 @@ package com.quantweb.springserver.domain.back_test.converter;
 
 
 import com.quantweb.springserver.domain.back_test.DTO.request.BackTestInput;
+import com.quantweb.springserver.domain.back_test.DTO.request.BackTestRequestDto;
 import com.quantweb.springserver.domain.back_test.DTO.response.BackTestDetailsDto;
 import com.quantweb.springserver.domain.back_test.DTO.response.BackTestResponseDto;
 import com.quantweb.springserver.domain.back_test.DTO.response.InvestmentResultDto;
@@ -22,24 +23,24 @@ import java.util.stream.Collectors;
 
 public class BackTestConverter {
 
-    public static BackTest toBackTest(User user, BackTestInput backTestInput, InvestmentResultDto responseDto){
+    public static BackTest toBackTest(User user, BackTestRequestDto.BackTestSaveDto responseDto){
 
         return BackTest.builder()
                 .user(user)
-                .name(backTestInput.getStrategy_setup().getStrategy_name())
-                .stockNum(backTestInput.getStrategy_setup().getStock_selection())
-                .initInvestmentFund(responseDto.getInitial_amount())
-                .fees(backTestInput.getStrategy_setup().getFee())
-                .rebalancePeriod(backTestInput.getStrategy_setup().getRebalancing_period())
-                .investStartDate(LocalDate.parse(responseDto.getPeriod().getStart_date()))
-                .investEndDate(LocalDate.parse(responseDto.getPeriod().getEnd_date()))
-                .yearlyAverageProfit(responseDto.getAnnualized_return())
-                .realizedProfit(responseDto.getRealized_profit())
-                .unrealized_profit(responseDto.getUnrealized_profit())
-                .finalAsset(responseDto.getFinal_asset())
+                .name(responseDto.getBackTestInfo().getName())
+                .stockNum(responseDto.getBackTestInfo().getStockNum())
+                .initInvestmentFund(responseDto.getInvestment_result().getInitial_amount())
+                .fees(responseDto.getBackTestInfo().getFees())
+                .rebalancePeriod(responseDto.getBackTestInfo().getRebalancingPeriod())
+                .investStartDate(LocalDate.parse(responseDto.getInvestment_result().getPeriod().getStart_date()))
+                .investEndDate(LocalDate.parse(responseDto.getInvestment_result().getPeriod().getEnd_date()))
+                .yearlyAverageProfit(responseDto.getInvestment_result().getAnnualized_return())
+                .realizedProfit(responseDto.getInvestment_result().getRealized_profit())
+                .unrealized_profit(responseDto.getInvestment_result().getUnrealized_profit())
+                .finalAsset(responseDto.getInvestment_result().getFinal_asset())
                 .marketShared(false)
                 .deletedAt(null)
-                .technicalStrategy(backTestInput.getStrategy_setup().getBacktest_strategy())
+                .technicalStrategy(responseDto.getBackTestInfo().getTechnicalStrategy())
                 .build();
     }
 
@@ -108,10 +109,10 @@ public class BackTestConverter {
                 .build();
     }
 
-    public static List<BackTestResponseDto> toBackTestList(List<BackTest> backTests){
+    public static List<BackTestResponseDto.BackTestSaveDto> toBackTestList(List<BackTest> backTests){
 
         return backTests.stream()
-                .map(bt -> new BackTestResponseDto(bt.getId(), bt.getName()))
+                .map(bt -> new BackTestResponseDto.BackTestSaveDto(bt.getId(), bt.getName()))
                 .toList();
     }
 }

--- a/src/main/java/com/quantweb/springserver/domain/back_test/entity/BackTest.java
+++ b/src/main/java/com/quantweb/springserver/domain/back_test/entity/BackTest.java
@@ -81,10 +81,12 @@ public class BackTest extends BaseTimeEntity {
     @OneToMany(mappedBy = "backTest", cascade = CascadeType.ALL)
     private List<SalesTransactionHistory> salesTransactionHistories;
 
-    @OneToOne(mappedBy = "backTest", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "backTest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Graph graph;
 
     public void updateMarketShared(){
         this.marketShared = !marketShared;
     }
+
+
 }

--- a/src/main/java/com/quantweb/springserver/domain/investment_sectors_pie_chart/service/PieChartService.java
+++ b/src/main/java/com/quantweb/springserver/domain/investment_sectors_pie_chart/service/PieChartService.java
@@ -17,6 +17,7 @@ public class PieChartService {
 
     private final PieChartRepository pieChartRepository;
 
+    @Transactional
     public void savePieChart(ArrayList<StrategyInfoDto.InvestmentSectorsPieChartItem> investmentSectorsPieChart, BackTest backTest){
 
         investmentSectorsPieChart.forEach(

--- a/src/main/java/com/quantweb/springserver/domain/sales_transaction_history/service/TransactionHistoryService.java
+++ b/src/main/java/com/quantweb/springserver/domain/sales_transaction_history/service/TransactionHistoryService.java
@@ -1,5 +1,7 @@
 package com.quantweb.springserver.domain.sales_transaction_history.service;
 
+import com.quantweb.springserver.common.exception.CustomException;
+import com.quantweb.springserver.common.exception.ErrorCode;
 import com.quantweb.springserver.domain.back_test.DTO.response.InvestmentResultDto;
 import com.quantweb.springserver.domain.back_test.entity.BackTest;
 import com.quantweb.springserver.domain.sales_transaction_history.converter.TransactionHistoryConverter;
@@ -20,6 +22,7 @@ public class TransactionHistoryService {
 
     private final TransactionHistoryRepository transactionHistoryRepository;
 
+    @Transactional
     public void saveTransactionHistory(ArrayList<InvestmentResultDto.TransactionHistoryGraphItem> transactionHistory, BackTest backTest){
 
         transactionHistory.forEach(th -> {
@@ -29,7 +32,7 @@ public class TransactionHistoryService {
 
     public TransactionHistoryResponseDto getTransactionHistory(Long backtestId){
 
-        List<SalesTransactionHistory> transactionHistories = transactionHistoryRepository.findAllByBackTestId(backtestId).orElseThrow(() -> new RuntimeException("백테스트가 존재하지 않습니다."));
+        List<SalesTransactionHistory> transactionHistories = transactionHistoryRepository.findAllByBackTestId(backtestId).orElseThrow(() -> new CustomException(ErrorCode.BACKTEST_NOT_FOUND));
 
         return TransactionHistoryConverter.toTransactionHistoryResultDto(transactionHistories);
     }

--- a/src/main/java/com/quantweb/springserver/domain/stock/service/StockService.java
+++ b/src/main/java/com/quantweb/springserver/domain/stock/service/StockService.java
@@ -1,5 +1,7 @@
 package com.quantweb.springserver.domain.stock.service;
 
+import com.quantweb.springserver.common.exception.CustomException;
+import com.quantweb.springserver.common.exception.ErrorCode;
 import com.quantweb.springserver.domain.back_test.DTO.response.StrategyInfoDto;
 import com.quantweb.springserver.domain.back_test.entity.BackTest;
 import com.quantweb.springserver.domain.investment_sectors_pie_chart.entity.InvestmentSectorsPieChart;
@@ -21,6 +23,7 @@ public class StockService {
   private final StockRepository stockRepository;
   private final PieChartRepository pieChartRepository;
 
+  @Transactional
   public void saveStock(List<StrategyInfoDto.Stock> stocks, BackTest backTest) {
 
     stocks.forEach(
@@ -34,12 +37,12 @@ public class StockService {
     List<Stock> stocks =
         stockRepository
             .findAllByBackTestId(backtestId)
-            .orElseThrow(() -> new RuntimeException("백테스트가 존재하지 않습니다."));
+            .orElseThrow(() -> new CustomException(ErrorCode.BACKTEST_NOT_FOUND));
 
     List<InvestmentSectorsPieChart> investmentSectorsPieCharts =
         pieChartRepository
             .findAllByBackTestId(backtestId)
-            .orElseThrow(() -> new RuntimeException("백테스트가 존재하지 않습니다."));
+            .orElseThrow(() -> new CustomException(ErrorCode.BACKTEST_NOT_FOUND));
 
     return StockConverter.toStockResponseDto(stocks, investmentSectorsPieCharts);
   }


### PR DESCRIPTION

## 📝작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 백테스팅 실행하기가 기존에는 실행하면 바로 저장되게 하였는데 피그마에 저장 버튼이 따로 있는 것을 확인하여 실행과 저장 구분하였습니다.
- 백테스팅 수정하기는 저장된 백테스트를 수정하는 기능은 필요없어 보이고 
저장전까지 백테스트 인풋값을 자유롭게 수정 가능한데 기존 백테스팅 실행하기 기능으로 수행하면 될 것 같습니다.
- 백테스팅 삭제하기 구현했습니다.

ex) #64 
